### PR TITLE
Extend speakers form

### DIFF
--- a/api/airtable/index.js
+++ b/api/airtable/index.js
@@ -215,6 +215,31 @@ module.exports = async (req, res) => {
         ]
       },
       {
+        title: "Activities",
+        description: `We would love to have you at our speakers dinner on Wednesday evening (24 Aug). In the afternoon before the dinner, we are offering a <a href="https://www.zuerich.com/en/visit/tours-excursions/zurich-old-town-walking-tour#/">walking tour</a> of the Zurich old town.`,
+        fields: [
+          {
+            name: "Speakers Dinner",
+            type: "checkbox",
+            description: "I will join the dinner",
+            value: "true",
+            checked: true
+          },
+          {
+            name: "Dietary Preferences",
+            type: "textarea",
+            description:
+              "Any dietary preferences (vegetarian, vegan, gluten-free etc.)"
+          },
+          {
+            name: "City Tour",
+            type: "checkbox",
+            description: "I will join the walking tour",
+            value: "true"
+          }
+        ]
+      },
+      {
         title: "Payment Details",
         description: `Please let us know your bank account details - we will use it to transfer your honorarium after the conference. If you prefer to send us an invoice after the event, that's totally fine too, and these would be our details (no worries, we will send it to you again later in an extensive pre-conference briefing):
   

--- a/components/Form.js
+++ b/components/Form.js
@@ -112,6 +112,7 @@ class Form extends Component {
                             aria-describedby={
                               field.description ? `${field.name}-desc` : null
                             }
+                            checked={field.checked}
                             required={field.required}
                           />
                         );
@@ -126,7 +127,7 @@ class Form extends Component {
                             ) : null}
                           </label>
                         </dt>
-                        <dd>
+                        <dd className={`form__field-element--${field.type}`}>
                           {element}
                           {field.description && (
                             <div

--- a/components/Form.scss
+++ b/components/Form.scss
@@ -65,6 +65,17 @@
     }
   }
 
+  &__field-element {
+    &--checkbox {
+      display: flex;
+      gap: 0.5rem;
+
+      .form__field-description {
+        margin-top: 0.125rem;
+      }
+    }
+  }
+
   &__field-description {
     margin-top: 1em;
   }


### PR DESCRIPTION
Demo: https://website-relaunch-40icgglqe-front-conference-zurich.vercel.app/speakers-form

- Add activities fields:
![image](https://user-images.githubusercontent.com/654171/169689988-9097a397-ca89-4dc8-89e3-30e2aab5b997.png)
- Display checkbox hint texts next to checkboxes
